### PR TITLE
Updates to work on latest version of fabric8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -494,66 +494,40 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>com.spotify</groupId>
-                <artifactId>docker-maven-plugin</artifactId>
-                <version>0.4.5</version>
-                <configuration>
-                    <imageName>shiftwork</imageName>
-                    <dockerDirectory>src/main/docker</dockerDirectory>
-                    <resources>
-                        <resource>
-                            <targetPath>/</targetPath>
-                            <directory>${project.build.directory}</directory>
-                            <include>${project.build.finalName}.war</include>
-                        </resource>
-                    </resources>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>io.fabric8</groupId>
-                <artifactId>docker-maven-plugin</artifactId>
-                <version>0.14.2</version>
+                <artifactId>fabric8-maven-plugin</artifactId>
+                <version>3.2.20</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>resource</goal>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
                 <configuration>
                     <images>
                         <image>
-                            <name>${docker.image}</name>
+                            <name>staffrostering/${project.artifactId}:${project.version}</name>
                             <build>
                                 <from>${docker.from}</from>
                                 <assembly>
-                                    <basedir>/app</basedir>
                                     <descriptorRef>${docker.assemblyDescriptorRef}</descriptorRef>
                                 </assembly>
+                                <env>
+                                    <HTTP_PORT>8080</HTTP_PORT>
+                                </env>
                                 <ports>
+                                    <port>8778</port>
                                     <port>8080</port>
                                 </ports>
                                 <cmd>
-                                    <shell>java -jar /app/${project.artifactId}-${project.version}.war --spring.profiles.active=prod</shell>
+                                    <shell>java -jar /maven/${project.artifactId}-${project.version}.war --spring.profiles.active=prod</shell>
                                 </cmd>
                             </build>
                         </image>
                     </images>
                 </configuration>
-            </plugin>
-            <plugin>
-                <groupId>io.fabric8</groupId>
-                <artifactId>fabric8-maven-plugin</artifactId>
-                <version>2.2.100</version>
-                <executions>
-                    <execution>
-                        <id>json</id>
-                        <phase>generate-resources</phase>
-                        <goals>
-                            <goal>json</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>attach</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>attach</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>io.gatling</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,8 @@
         <commons-lang.version>2.6</commons-lang.version>
         <docker.assemblyDescriptorRef>artifact</docker.assemblyDescriptorRef>
         <docker.from>docker.io/fabric8/java-jboss-openjdk8-jdk:1.0.10</docker.from>
-        <docker.image>shiftwork/${project.artifactId}:${project.version}</docker.image>
+        <!--the docker org needs to match the last part of the projects maven group id for the pipelines to tag image in plain kubernetes env -->
+        <docker.image>staffrostering/${project.artifactId}:${project.version}</docker.image>
         <docker.port.container.http>8080</docker.port.container.http>
         <docker.port.container.jolokia>8778</docker.port.container.jolokia>
         <fabric8.iconRef>icons/spring-boot</fabric8.iconRef>
@@ -336,6 +337,7 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-loader-tools</artifactId>
         </dependency>
+        <!-- jhipster-needle-maven-add-dependency -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-aop</artifactId>
@@ -494,6 +496,23 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>com.spotify</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
+                <version>0.4.5</version>
+                <configuration>
+                    <imageName>shiftwork</imageName>
+                    <dockerDirectory>src/main/docker</dockerDirectory>
+                    <resources>
+                        <resource>
+                            <targetPath>/</targetPath>
+                            <directory>${project.build.directory}</directory>
+                            <include>${project.build.finalName}.war</include>
+                        </resource>
+                    </resources>
+                </configuration>
+            </plugin>
+            <plugin>
+            <plugin>
                 <groupId>io.fabric8</groupId>
                 <artifactId>fabric8-maven-plugin</artifactId>
                 <version>3.2.20</version>
@@ -508,7 +527,7 @@
                 <configuration>
                     <images>
                         <image>
-                            <name>staffrostering/${project.artifactId}:${project.version}</name>
+                            <name>${docker.image}</name>
                             <build>
                                 <from>${docker.from}</from>
                                 <assembly>
@@ -518,8 +537,8 @@
                                     <HTTP_PORT>8080</HTTP_PORT>
                                 </env>
                                 <ports>
-                                    <port>8778</port>
                                     <port>8080</port>
+                                    <port>8778</port>
                                 </ports>
                                 <cmd>
                                     <shell>java -jar /maven/${project.artifactId}-${project.version}.war --spring.profiles.active=prod</shell>
@@ -527,6 +546,10 @@
                             </build>
                         </image>
                     </images>
+                    <!--<enricher>-->
+                    <!-- the default sb health enricher wont work if auth is enabled -->
+                    <!--<excludes>spring-boot-health-check</excludes>-->
+                    <!--</enricher>-->
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/fabric8/postgresql-deployment.yaml
+++ b/src/main/fabric8/postgresql-deployment.yaml
@@ -1,0 +1,39 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: postgresql
+  labels:
+    service: postgresql
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      service: postgresql
+  template:
+    metadata:
+      labels:
+        service: postgresql
+    spec:
+      containers:
+      - env:
+        - name: POSTGRES_USER
+          value: staffservice
+        - name: POSTGRES_PASSWORD
+        image: docker.io/postgres:9.5.1
+        name: postgresql
+        ports:
+        - containerPort: 5432
+          protocol: TCP
+        readinessProbe:
+          tcpSocket:
+            port: 5432
+          initialDelaySeconds: 20
+          timeoutSeconds: 10
+          failureThreshold: 3
+        livenessProbe:
+          tcpSocket:
+            port: 5432
+          initialDelaySeconds: 120
+          timeoutSeconds: 10
+          failureThreshold: 3
+      restartPolicy: Always

--- a/src/main/fabric8/postgresql-service.yaml
+++ b/src/main/fabric8/postgresql-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    service: postgresql
+  name: postgresql
+spec:
+  ports:
+  - name: "5432"
+    port: 5432
+    protocol: TCP
+    targetPort: 5432
+  selector:
+    service: postgresql

--- a/src/main/fabric8/shiftwork-deployment.yml
+++ b/src/main/fabric8/shiftwork-deployment.yml
@@ -1,0 +1,19 @@
+spec:
+  selector:
+    matchLabels:
+      service: shiftwork
+  template:
+    metadata:
+      labels:
+        service: shiftwork
+    spec:
+      containers:
+      - image: ${docker.image}
+        livenessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 180
+        readinessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 10

--- a/src/main/fabric8/shiftwork-svc.yml
+++ b/src/main/fabric8/shiftwork-svc.yml
@@ -1,0 +1,9 @@
+metadata:
+  labels:
+    service: shiftwork
+spec:
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 8080

--- a/src/main/resources/config/application-prod.yml
+++ b/src/main/resources/config/application-prod.yml
@@ -18,10 +18,10 @@ spring:
         livereload:
             enabled: false
     datasource:
-        url: jdbc:postgresql://localhost:5432/staffservice
+        url: jdbc:postgresql://postgresql:5432/staffservice
         name:
         username: staffservice
-        password:
+        password: 
     jpa:
         database-platform: com.teammachine.staffrostering.domain.util.FixedPostgreSQL82Dialect
         database: POSTGRESQL


### PR DESCRIPTION
- upgraded to fabric8-maven-plugin 3.x
- added postgresql deployment (data volume not mounted - this needs to be done to preserve data!!!)
- disabled auto spring boot liveness checks as they wont work when auth is on the UI
- added tcp liveness and readiness checks

__NOTE__ the first shiftwork deployment will fail readiness check because its waiting for the postgres service to be ready.  Kubernetes will automatically restart the pod after a short while and connect to postgress.
